### PR TITLE
Fixed crash caused by WatchNextServices

### DIFF
--- a/app/src/main/java/com/google/android/tvhomescreenchannels/SynchronizeDatabaseJobService.java
+++ b/app/src/main/java/com/google/android/tvhomescreenchannels/SynchronizeDatabaseJobService.java
@@ -50,7 +50,7 @@ public class SynchronizeDatabaseJobService extends JobService {
     static void schedule(Context context) {
         JobScheduler scheduler = context.getSystemService(JobScheduler.class);
         scheduler.schedule(new JobInfo.Builder(0,
-                new ComponentName(context, SynchronizeDatabaseJobService.class))
+                new ComponentName(context, SynchronizeDatabaseJobService.class)).setOverrideDeadline(0)
                 .build());
     }
 

--- a/app/src/main/java/com/google/android/tvhomescreenchannels/scheduler/AddWatchNextService.java
+++ b/app/src/main/java/com/google/android/tvhomescreenchannels/scheduler/AddWatchNextService.java
@@ -55,7 +55,7 @@ public class AddWatchNextService extends JobService {
         bundle.putString(CARD_IMAGE_URL_KEY, clipData.getCardImageUrl());
 
         scheduler.schedule(new JobInfo.Builder(1,
-                new ComponentName(context, AddWatchNextService.class))
+                new ComponentName(context, AddWatchNextService.class)).setOverrideDeadline(0)
                 .setExtras(bundle)
                 .build());
     }

--- a/app/src/main/java/com/google/android/tvhomescreenchannels/scheduler/DeleteWatchNextService.java
+++ b/app/src/main/java/com/google/android/tvhomescreenchannels/scheduler/DeleteWatchNextService.java
@@ -43,7 +43,7 @@ public class DeleteWatchNextService extends JobService {
         bundle.putString(ID_KEY, clipId);
 
         scheduler.schedule(new JobInfo.Builder(1, new ComponentName(context,
-                DeleteWatchNextService.class))
+                DeleteWatchNextService.class)).setOverrideDeadline(0)
                 .setExtras(bundle)
                 .build());
     }


### PR DESCRIPTION
- Crash caused by scheduling JobService without any constraints, which throws IllegalStateException